### PR TITLE
Fix formatting, grammar, and punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ of the transaction: how we mirror our _local_ repository to a _remote_ repositor
 using `git push` and `git remote`.
 
 Once your code is on a _remote_, it's backed up &mdash; which is always a good
-thing &mdash; Also, once you push to a remote you can choose whether to let
+thing. Also, once you push to a remote, you can choose whether to let
 others `fork` or `clone` and benefit from it. Let's learn how to `push` our code!
 
 ## Create a Remote Repository on GitHub
@@ -31,13 +31,13 @@ There are a few steps to follow to create a _remote_ repository on GitHub.
 
 1. Go to: [github.com/new](https://github.com/new), while logged into GitHub.
 
-2. Enter a name for your repository in the `Repository name` field. You can name
+2. Enter a name for your repository in the "Repository name" field. You can name
 it whatever you'd like; be creative! The default options are fine as-is — don't
-initialize the new repository with a README or add a `.gitignore` or license.
-Click the green `Create repository` button.
+initialize the new repository with a `README` or add a `.gitignore` or license.
+Click the green 'Create repository' button.
 
 3. After you create the _remote_ repository, you should see a "Quick setup"
-page. Make sure the `SSH` option is selected, then click the "Copy to clipboard" 
+page. Make sure the 'SSH' option is selected, then click the "Copy to clipboard" 
 symbol next to the repo URL (pictured) to copy the URL. (We'll use this in the 
 next section.)
 
@@ -53,7 +53,7 @@ local repository uploaded to GitHub. Follow the appropriate steps below:
 ### For the In-Browser Learn IDE
 
 1. On this Learn.co lesson page, click the 'Sandbox' button to open up a blank
-IDE
+IDE.
 
 2. First, we want to create a folder for our repository, which we'll call
 `my_new_directory`. In the terminal, type `mkdir my_new_directory`. The folder
@@ -80,28 +80,31 @@ repository. In your terminal, type `git init`. Your terminal should show that an
 7. Type `git add README.md` to stage the new `README.md` file so it will be tracked by
 `git`.
 
-8. Now, type `git commit -m 'initialize git'`. This will create the first commit
+8. Now, type `git commit -m "Initialize git"`. This will create the first commit
 for this local repository, which will allow us to push our work to the remote
 repository we created earlier.
 
 ### For the Standalone Learn IDE
 
-1. Create a new directory and add a file. You can run this series of commands:
+1. We want to create a new directory and add a file so our first step is to change into our `code` directory by typing `cd ~/code` into the terminal. (If your development directory is named something other than `~/code`, that's fine, `cd` into whatever yours is called.) Our terminal should display `code` (or whatever you decided to name your development directory), indicating that you are now inside of our development directory.
 
-    * Change into your `code` directory: `cd ~/code`
-      * If your development directory is named something other than `~/code`, that's fine, `cd` into whatever yours is called.
-    * Create a new directory named `my_new_directory`: `mkdir my_new_directory`
-    * Change into the newly-created directory: `cd my_new_directory`
-    * Create a new file named `README.md`: `touch README.md`
-    * Add some text to the new file: `echo "This is my readme file" > README.md`
+2. Next, create a new directory named `my_new_directory` by entering `mkdir my_new_directory` in the terminal.
 
-2. Now that we've got some basic content, we can initialize our local
-repository, so in your terminal, type `git init`. Your terminal should show that
+3. We're going to move from development directory into the newly-created directory by typing `cd my_new_directory`. Our terminal should display `my_new_directory`.
+
+4. Let's create a new file named `README.md`. Type `touch README.md` into the terminal. In the file tree, if you expand the folder `my_new_directory`, you should now see your `README.md` file. Click on it to open it in the text editor.
+
+5. We can directly type in content here, but we can also use our terminal skills
+to add content. So, in the terminal, type `echo "This is my readme file" >
+README.md`. If you've got the README file open, the new text will appear!
+
+6. Now that we've got some basic content, we can initialize our local
+repository. In your terminal, type `git init`. Our terminal should show that
 an 'empty Git repository' has been initialized.
 
-3. Type `git add README.md` to stage the new `README.md` file so it will be tracked by Git.
+7. Type `git add README.md` to stage the new `README.md` file so it will be tracked by Git.
 
-4. Now, type `git commit -m 'initialize git'`. This will create the first commit
+8. Now, type `git commit -m "Initialize git"`. This will create the first commit
 for this local repository, which will allow us to push our work to the remote we
 created earlier.
 
@@ -109,26 +112,28 @@ created earlier.
 
 To connect your local repository to the newly created GitHub repository, you
 must add a new remote to a remote name. Adding a remote involves giving `git` a "short name" and
-a "repository path." You copied the repository path from GitHub a few steps
+a "repository path". You copied the repository path from GitHub a few steps
 above.
 
 The repository path is a long bunch of technical words. The creators of Git
 thought it would be easier to type a "nickname" or a "short name" that points to
-that long "repository path." It's common to have a "default" remote. The default
-remote short name is called `origin`. So we're going to create a new remote with
+that long repository path. It's common to have a "default" remote. The default
+remote short name is called `origin`. So we're going to create a new remote with a 
 short name of `origin`.
 
-Make sure you've still got your remote Git info copied from GitHub, and type the
+Make sure you still have your remote Git info copied from GitHub, and type the
 following into the terminal:
 
-`git remote add origin <your-copied-remote-repository-URL>`.
+```bash
+my_new_directory $ git remote add origin <your-copied-remote-repository-URL>
+```
 
-This sets the remote, so you can now ***push*** code.
+This sets the remote so you can now ***push*** your code.
 
-You can use `git remote -v` (the `v` is for "verbose") to view the remote(s).
+You can use `git remote -v` (the `-v` is for "verbose") to view the remote(s).
 
 ```bash
-git remote -v
+my_new_directory $ git remote -v
 # View existing remotes
 # origin  git@github.com:OWNER/REPOSITORY.git (fetch)
 # origin  git@github.com:OWNER/REPOSITORY.git (push)
@@ -151,16 +156,14 @@ until later, but it's important to remember that `master` is a special branch, i
 the default name.
 
 ```bash
-git push -u origin master
+my_new_directory $ git push -u origin master
 ```
 
 This will push your code up to the remote repo/branch. The first time you push
 code up to a newly-added remote repository, use the `-u` flag to tell Git to
-"save" the remote repository as the default push destination:
+"save" the remote repository as the default push destination.
 
-`git push -u origin master`.
-
-For every subsequent push, you only need to enter `git push`
+For every subsequent push, you only need to enter `git push`.
 
 ## Conclusion
 


### PR DESCRIPTION
- Fixed the messed up formatting under the "For the Standalone Learn IDE" section
- Added `my_new_directory $` in bash codeblocks to keep with standards (as referenced in "Git Version Control Basics" lesson)
- Capitalized the beginning of the Git commit message examples to follow best practices
- Removed duplicate code under "Send Code to the Remote Repo with `git push`" section
- Changed code-formatted text to regular text in the "Create a Remote Repository on GitHub" section
  - Text refers to buttons and text in the browser, not code input
- Grammar and punctuation fixes